### PR TITLE
add claim to bill classification

### DIFF
--- a/opencivicdata/common.py
+++ b/opencivicdata/common.py
@@ -82,6 +82,7 @@ BILL_CLASSIFICATION_CHOICES = (
     ('proclamation', 'Proclamation'),
     ('nomination', 'Nomination'),
     ('contract', 'Contract'),
+    ('claim', 'Claim'),
     ('appointment', 'Appointment'),
     ('constitutional amendment', 'Constitutional Amendment'),
     ('petition', 'Petition'),


### PR DESCRIPTION
In Chicago, claims against the city, large and small, are handled by the city council. http://chicagocouncilmatic.org/search/?q=&topics=Small%20Claims

I would say these are a type of bill since the entire council approves the, at least as much of a a bill as 'contract'.