### PR TITLE
fix flake8 errors everywhere

### DIFF
--- a/opencivicdata/admin/__init__.py
+++ b/opencivicdata/admin/__init__.py
@@ -48,9 +48,9 @@ class OtherNameInline(admin.TabularInline):
     verbose_name = "Alternate name"
     verbose_name_plural = "Alternate names"
 
-#class MimetypeLinkInline(admin.TabularInline):
+# class MimetypeLinkInline(admin.TabularInline):
 #    fields = ('media_type', 'url')
-#class RelatedEntityInline(admin.TabularInline):
+# class RelatedEntityInline(admin.TabularInline):
 #    fields = ('name', 'entity_type', 'organization', 'person')
 
 # Divisions & Jurisdictions ##########
@@ -188,7 +188,7 @@ class PostAdmin(ModelAdmin):
     ]
     search_fields = ('organization__name', 'label')
 
-### People & Memberships #######
+# People & Memberships #######
 
 
 class PersonIdentifierInline(IdentifierInline):

--- a/opencivicdata/admin/__init__.py
+++ b/opencivicdata/admin/__init__.py
@@ -5,12 +5,13 @@ from .. import models
 
 # Helpers ##########
 
+
 class ModelAdmin(admin.ModelAdmin):
     """ deletion of top level objects is evil """
     def has_delete_permission(self, request, obj=None):
         return False
 
-    #we probably don't want to add anything through the interface
+    # we probably don't want to add anything through the interface
     def has_add_permission(self, request):
         return False
 
@@ -54,6 +55,7 @@ class OtherNameInline(admin.TabularInline):
 
 # Divisions & Jurisdictions ##########
 
+
 @admin.register(models.Division)
 class DivisionAdmin(ModelAdmin):
     list_display = ('name', 'id')
@@ -62,18 +64,18 @@ class DivisionAdmin(ModelAdmin):
     ordering = ('id',)
 
 
-
 class LegislativeSessionInline(ReadOnlyTabularInline):
     model = models.LegislativeSession
     readonly_fields = ('identifier', 'name')
     ordering = ('-identifier',)
 
+
 @admin.register(models.Jurisdiction)
 class JurisdictionAdmin(ModelAdmin):
     list_display = ('name', 'id')
     readonly_fields = fields = ('id', 'name', 'division', 'classification',
-                                'feature_flags','extras')
-    fields = readonly_fields + ('url',)
+                                'feature_flags', 'extras')
+    fields = readonly_fields + ('url', )
     ordering = ('id',)
     inlines = [LegislativeSessionInline]
 
@@ -107,7 +109,7 @@ class PostInline(admin.TabularInline):
     fields = readonly_fields = ('label', 'role')
     ordering = ('label',)
     can_delete = False
-    show_change_link = True # Django 1.8?
+    show_change_link = True
 
 
 class OrgMembershipInline(ReadOnlyTabularInline):
@@ -117,6 +119,7 @@ class OrgMembershipInline(ReadOnlyTabularInline):
     fields = ('person', 'post', 'label', 'role', 'start_date', 'end_date', 'id')
     extra = 0
     can_delete = True
+
 
 @admin.register(models.Organization)
 class OrganizationAdmin(ModelAdmin):
@@ -140,8 +143,7 @@ class OrganizationAdmin(ModelAdmin):
     def get_org_name(self, obj):
         parent = obj.parent
         if parent:
-            return "{org} ({parent})".format(org=obj.name,
-                                            parent=parent.name)
+            return "{org} ({parent})".format(org=obj.name, parent=parent.name)
         return obj.name
     get_org_name.short_description = "Name"
     get_org_name.allow_tags = True
@@ -151,7 +153,7 @@ class OrganizationAdmin(ModelAdmin):
         jurisdiction = obj.jurisdiction
         if jurisdiction:
             admin_url = urlresolvers.reverse('admin:opencivicdata_jurisdiction_change',
-                                                args=(jurisdiction.pk,))
+                                             args=(jurisdiction.pk,))
             tmpl = '<a href="%s">%s</a>'
             return tmpl % (admin_url, jurisdiction.name)
 
@@ -164,7 +166,7 @@ class OrganizationAdmin(ModelAdmin):
     list_select_related = ('jurisdiction',)
     list_display = ('get_org_name', 'get_jurisdiction', 'classification')
     ordering = ('name',)
-    
+
 
 class PostContactDetailInline(ContactDetailInline):
     model = models.PostContactDetail
@@ -184,9 +186,10 @@ class PostAdmin(ModelAdmin):
         PostContactDetailInline,
         PostLinkInline,
     ]
-    search_fields = ('organization__name','label')
+    search_fields = ('organization__name', 'label')
 
 ### People & Memberships #######
+
 
 class PersonIdentifierInline(IdentifierInline):
     model = models.PersonIdentifier
@@ -219,7 +222,8 @@ class MembershipInline(ReadOnlyTabularInline):
     extra = 0
     can_delete = True
 
-#TODO field locking
+
+# TODO field locking
 @admin.register(models.Person)
 class PersonAdmin(ModelAdmin):
     search_fields = ['name']
@@ -241,18 +245,19 @@ class PersonAdmin(ModelAdmin):
         MembershipInline
     ]
 
-
     def get_memberships(self, obj):
         memberships = obj.memberships.select_related('organization__jurisdiction')
         html = []
         SHOW_N = 5
         for memb in memberships[:SHOW_N]:
             org = memb.organization
-            admin_url = urlresolvers.reverse('admin:opencivicdata_organization_change', args=(org.pk,))
+            admin_url = urlresolvers.reverse('admin:opencivicdata_organization_change',
+                                             args=(org.pk,))
             tmpl = '<a href="%s">%s%s</a>\n'
             html.append(tmpl % (
                 admin_url,
-                memb.organization.jurisdiction.name + ": " if memb.organization.jurisdiction else '',
+                (memb.organization.jurisdiction.name +
+                 ": " if memb.organization.jurisdiction else ''),
                 memb.organization.name))
         more = len(memberships) - SHOW_N
         if 0 < more:
@@ -286,21 +291,20 @@ class BillIdentifierInline(IdentifierInline):
 
 class BillActionInline(ReadOnlyTabularInline):
     model = models.BillAction
+
     def get_related_entities(self, obj):
         ents = obj.related_entities.all()
-        #this seems to be a uuid problem, get
-        #rid of the below return stmt when uuids are fixed
+        # this seems to be a uuid problem, get
+        # rid of the below return stmt when uuids are fixed
         return None
         ent_list = [e.name for e in ents]
         return ', '.join(ent_list)
 
     get_related_entities.short_description = 'Related Entities'
     get_related_entities.allow_tags = True
-            
-    list_select_related = ('BillActionRelatedEntity',)
-    readonly_fields = ('date', 'organization',
-                        'description','get_related_entities')
 
+    list_select_related = ('BillActionRelatedEntity',)
+    readonly_fields = ('date', 'organization', 'description', 'get_related_entities')
 
 
 class RelatedBillInline(ReadOnlyTabularInline):
@@ -308,6 +312,7 @@ class RelatedBillInline(ReadOnlyTabularInline):
     fk_name = 'bill'
     readonly_fields = fields = ('identifier', 'legislative_session', 'relation_type')
     extra = 0
+
 
 class BillSponsorshipInline(ReadOnlyTabularInline):
     model = models.BillSponsorship
@@ -317,8 +322,9 @@ class BillSponsorshipInline(ReadOnlyTabularInline):
 
 class BillDocumentInline(ReadOnlyTabularInline):
     model = models.BillDocument
+
     def get_link(self, obj):
-        return None #get rid of this line when uuid issue fixed
+        return None  # TODO: get rid of this line when uuid issue fixed
         link = obj.links.first()
         return link.url
 
@@ -326,13 +332,14 @@ class BillDocumentInline(ReadOnlyTabularInline):
     get_link.allow_tags = True
 
     list_select_related = ('BillDocumentLink',)
-    readonly_fields = ('note','date', 'get_link')
+    readonly_fields = ('note', 'date', 'get_link')
 
 
 class BillVersionInline(ReadOnlyTabularInline):
     model = models.BillVersion
+
     def get_link(self, obj):
-        return None #get rid of this line when uuid issue fixed
+        return None   # TODO: get rid of this line when uuid issue fixed
         link = obj.links.first()
         return link.url
 
@@ -340,7 +347,8 @@ class BillVersionInline(ReadOnlyTabularInline):
     get_link.allow_tags = True
 
     list_select_related = ('BillVersionLink',)
-    readonly_fields = ('note','date', 'get_link')
+    readonly_fields = ('note', 'date', 'get_link')
+
 
 class BillSourceInline(ReadOnlyTabularInline):
     fields = ('url', 'note')
@@ -352,7 +360,7 @@ class BillAdmin(ModelAdmin):
     readonly_fields = fields = (
         'identifier', 'legislative_session', 'bill_classifications',
         'from_organization', 'title', 'id', 'extras')
-    search_fields = ['identifier', 'title',]
+    search_fields = ['identifier', 'title']
     list_select_related = (
         'sources',
         'legislative_session',
@@ -370,8 +378,7 @@ class BillAdmin(ModelAdmin):
         BillDocumentInline,
     ]
 
-
-    def bill_classifications(self,obj):
+    def bill_classifications(self, obj):
         return ", ".join(obj.classification)
 
     def get_jurisdiction_name(self, obj):

--- a/opencivicdata/admin/event.py
+++ b/opencivicdata/admin/event.py
@@ -61,8 +61,8 @@ class EventDocumentAdmin(admin.ModelAdmin):
     list_display = ('event', 'date', 'note')
 
 
-#@admin.register(models.EventDocumentLink)
-#class EventDocumentLinkAdmin(base.MimetypeLinkAdmin):
+# @admin.register(models.EventDocumentLink)
+# class EventDocumentLinkAdmin(base.MimetypeLinkAdmin):
 #    readonly_fields = ('document',)
 #    list_display = ('document', 'media_type', 'url',)
 

--- a/opencivicdata/admin/event.py
+++ b/opencivicdata/admin/event.py
@@ -7,7 +7,7 @@ from . import base
 
 @admin.register(models.EventLocation)
 class EventLocationAdmin(admin.ModelAdmin):
-   pass
+    pass
 
 
 class EventLinkInline(base.LinkAdminInline):
@@ -48,6 +48,7 @@ class EventAdmin(admin.ModelAdmin):
         EventSourceInline,
         EventParticipantInline,
         ]
+
 
 @admin.register(models.EventMedia)
 class EventMediaAdmin(admin.ModelAdmin):
@@ -105,4 +106,3 @@ class EventAgendaMediaAdmin(admin.ModelAdmin):
 @admin.register(models.EventAgendaMediaLink)
 class EventAgendaMediaLinkAdmin(admin.ModelAdmin):
     pass
-

--- a/opencivicdata/admin/vote.py
+++ b/opencivicdata/admin/vote.py
@@ -2,7 +2,6 @@ from django.contrib import admin
 from opencivicdata.models import vote as models
 
 
-
 class VoteCountInline(admin.TabularInline):
     model = models.VoteCount
     fields = readonly_fields = ('option', 'value')
@@ -56,4 +55,3 @@ class PersonVoteAdmin(admin.ModelAdmin):
 @admin.register(models.VoteSource)
 class VoteSourceAdmin(admin.ModelAdmin):
     pass
-

--- a/opencivicdata/apps.py
+++ b/opencivicdata/apps.py
@@ -1,6 +1,7 @@
 from django.apps import AppConfig
 import os
 
+
 class BaseConfig(AppConfig):
     name = 'opencivicdata'
     verbose_name = 'Open Civic Data'

--- a/opencivicdata/common.py
+++ b/opencivicdata/common.py
@@ -2,8 +2,6 @@
 Module for declaration of common constants available throughout Open Civic Data code.
 """
 
-import re
-
 DIVISION_ID_REGEX = r'^ocd-division/country:[a-z]{2}(/[^\W\d]+:[\w.~-]+)*$'
 JURISDICTION_ID_REGEX = r'^ocd-jurisdiction/country:[a-z]{2}(/[^\W\d]+:[\w.~-]+)*/\w+$'
 
@@ -25,6 +23,9 @@ The only exception to this would be translations, which should simply exist as t
 the display name (2nd attribute).
 """
 
+# NOTE: this list explicitly does not include RFC 6350s 'cell' as that is redundant with
+# voice and the distinction will only lead to confusion.  contact_detail.note can be
+# used to indicate if something is a home, work, cell, etc.
 CONTACT_TYPE_CHOICES = (
     ('address', 'Postal Address'),
     ('email', 'Email'),
@@ -35,9 +36,6 @@ CONTACT_TYPE_CHOICES = (
     ('video', 'Video Phone'),
     ('pager', 'Pager'),
     ('textphone', 'Device for people with hearing impairment'),
-# NOTE: this list explicitly does not include RFC 6350s 'cell' as that is redundant with
-# voice and the distinction will only lead to confusion.  contact_detail.note can be
-# used to indicate if something is a home, work, cell, etc.
 )
 CONTACT_TYPES = _keys(CONTACT_TYPE_CHOICES)
 

--- a/opencivicdata/management/commands/loaddivisions.py
+++ b/opencivicdata/management/commands/loaddivisions.py
@@ -1,12 +1,7 @@
 from __future__ import print_function
-import io
-import os
-import csv
-from subprocess import check_call
-from optparse import make_option
 
-from django.db import transaction, connection
-from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.core.management.base import BaseCommand
 
 from opencivicdata.divisions import Division as FileDivision
 from ...models import Division

--- a/opencivicdata/models/base.py
+++ b/opencivicdata/models/base.py
@@ -17,7 +17,7 @@ class OCDIDField(models.CharField):
             #       = 4 + len(ocd_type) + 1 + 36
             #       = len(ocd_type) + 41
             kwargs['max_length'] = 41 + len(self.ocd_type)
-            regex = '^ocd-' + self.ocd_type  + '/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$'
+            regex = '^ocd-' + self.ocd_type + '/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$'
         else:
             kwargs['max_length'] = 300
             regex = common.JURISDICTION_ID_REGEX
@@ -36,7 +36,6 @@ class OCDIDField(models.CharField):
         kwargs.pop('primary_key')
         kwargs['ocd_type'] = self.ocd_type
         return (name, path, args, kwargs)
-
 
 
 class OCDBase(models.Model):

--- a/opencivicdata/models/bill.py
+++ b/opencivicdata/models/bill.py
@@ -3,7 +3,7 @@ from djorm_pgarray.fields import ArrayField
 
 from .base import (OCDBase, LinkBase, OCDIDField, RelatedBase, RelatedEntityBase, MimetypeLinkBase,
                    IdentifierBase)
-from .people_orgs import Organization, Person
+from .people_orgs import Organization
 from .jurisdiction import LegislativeSession
 from .. import common
 
@@ -53,7 +53,7 @@ class BillAbstract(RelatedBase):
     bill = models.ForeignKey(Bill, related_name='abstracts')
     abstract = models.TextField()
     note = models.TextField(blank=True)
-    date = models.TextField(max_length=10, blank=True) # YYYY[-MM[-DD]]
+    date = models.TextField(max_length=10, blank=True)  # YYYY[-MM[-DD]]
 
 
 class BillTitle(RelatedBase):

--- a/opencivicdata/models/bill.py
+++ b/opencivicdata/models/bill.py
@@ -27,27 +27,6 @@ class Bill(OCDBase):
             ['from_organization', 'legislative_session', 'identifier'],
         ]
 
-    # ------------------------------------------------------------------------
-    # Display methods used in the admin.
-    # ------------------------------------------------------------------------
-    def get_jurisdiction_name(self):
-        return self.legislative_session.jurisdiction.name
-
-    def get_session_name(self):
-        return self.legislative_session.name
-
-    def get_truncated_sponsors(self):
-        spons = ', '.join(s.name for s in self.sponsorships.all()[:5])
-        return defaultfilters.truncatewords(spons, 10)
-
-    def get_truncated_title(self):
-        return defaultfilters.truncatewords(self.title, 25)
-
-    get_jurisdiction_name.short_description = 'Jurisdiction'
-    get_session_name.short_description = 'Session'
-    get_truncated_sponsors.short_description = 'Sponsors'
-    get_truncated_title.short_description = 'Title'
-
 
 class BillAbstract(RelatedBase):
     bill = models.ForeignKey(Bill, related_name='abstracts')

--- a/opencivicdata/models/event.py
+++ b/opencivicdata/models/event.py
@@ -56,6 +56,7 @@ class Event(OCDBase):
             ['jurisdiction', 'start_time', 'name']
         ]
 
+
 class EventMedia(EventMediaBase):
     event = models.ForeignKey(Event, related_name='media')
 

--- a/opencivicdata/models/jurisdiction.py
+++ b/opencivicdata/models/jurisdiction.py
@@ -2,7 +2,7 @@ from django.db import models
 from djorm_pgarray.fields import ArrayField
 
 from ..common import JURISDICTION_CLASSIFICATION_CHOICES, SESSION_CLASSIFICATION_CHOICES
-from .base import OCDBase, LinkBase, OCDIDField, RelatedBase
+from .base import OCDBase, OCDIDField, RelatedBase
 from .division import Division
 
 
@@ -23,7 +23,8 @@ class LegislativeSession(RelatedBase):
     jurisdiction = models.ForeignKey(Jurisdiction, related_name='legislative_sessions')
     identifier = models.CharField(max_length=100)
     name = models.CharField(max_length=300)
-    classification = models.CharField(max_length=100, choices=SESSION_CLASSIFICATION_CHOICES, blank=True)
+    classification = models.CharField(max_length=100, choices=SESSION_CLASSIFICATION_CHOICES,
+                                      blank=True)
     start_date = models.CharField(max_length=10)    # YYYY[-MM[-DD]]
     end_date = models.CharField(max_length=10)    # YYYY[-MM[-DD]]
 

--- a/opencivicdata/models/people_orgs.py
+++ b/opencivicdata/models/people_orgs.py
@@ -6,6 +6,7 @@ from .. import common
 
 # abstract models
 
+
 class ContactDetailBase(RelatedBase):
     type = models.CharField(max_length=50, choices=common.CONTACT_TYPE_CHOICES)
     value = models.CharField(max_length=300)

--- a/opencivicdata/models/vote.py
+++ b/opencivicdata/models/vote.py
@@ -33,6 +33,7 @@ class VoteEvent(OCDBase):
             ['legislative_session', 'bill']
         ]
 
+
 class VoteCount(RelatedBase):
     vote = models.ForeignKey(VoteEvent, related_name='counts')
     option = models.CharField(max_length=50, choices=common.VOTE_OPTION_CHOICES)

--- a/opencivicdata/tests/test_loaddivisions.py
+++ b/opencivicdata/tests/test_loaddivisions.py
@@ -3,8 +3,9 @@ import pytest
 from django.core.management import call_command
 from opencivicdata.models import Division
 
+
 @pytest.mark.django_db
-@pytest.mark.skipif(sys.version_info < (3,3), reason="requires python3.3")
+@pytest.mark.skipif(sys.version_info < (3, 3), reason="requires python3.3")
 def test_loaddivisions():
     assert Division.objects.count() == 0
     call_command('loaddivisions', 'in')

--- a/opencivicdata/tests/test_models.py
+++ b/opencivicdata/tests/test_models.py
@@ -1,10 +1,12 @@
 import pytest
-from opencivicdata.models import (Jurisdiction, LegislativeSession, Division,
-                                  Organization, OrganizationIdentifier, OrganizationName,
-                                  OrganizationContactDetail, OrganizationSource,
-                                  Person, PersonIdentifier, PersonName, PersonContactDetail,
-                                  PersonLink, PersonSource, Post, PostContactDetail, PostLink,
-                                  Membership, MembershipContactDetail, MembershipLink)
+from opencivicdata.models import (Jurisdiction, LegislativeSession,                 # noqa
+                                  Division, Organization,                           # noqa
+                                  OrganizationIdentifier, OrganizationName,         # noqa
+                                  OrganizationContactDetail, OrganizationSource,    # noqa
+                                  Person, PersonIdentifier, PersonName,             # noqa
+                                  PersonContactDetail, PersonLink, PersonSource,    # noqa
+                                  Post, PostContactDetail, PostLink, Membership,    # noqa
+                                  MembershipContactDetail, MembershipLink)          # noqa
 from django.core.exceptions import ValidationError
 
 
@@ -37,20 +39,15 @@ def test_division_create():
 
 @pytest.mark.django_db
 def test_division_children_of():
-    us = Division.objects.create('ocd-division/country:us', name='US')
+    Division.objects.create('ocd-division/country:us', name='US')
     ak = Division.objects.create('ocd-division/country:us/state:ak', name='Alaska')
-    wild = Division.objects.create('ocd-division/country:us/state:ak/county:wild', name='Wild')
-    mild = Division.objects.create('ocd-division/country:us/state:ak/county:mild', name='Mild')
-    wild_a = Division.objects.create('ocd-division/country:us/state:ak/county:wild/place:a',
-                                     name='A')
-    wild_b = Division.objects.create('ocd-division/country:us/state:ak/county:wild/place:b',
-                                     name='B')
-    school = Division.objects.create('ocd-division/country:us/state:ak/county:wild/school:a',
-                                     name='A')
-    mild_a = Division.objects.create('ocd-division/country:us/state:ak/county:mild/place:a',
-                                     name='A')
-    mild_a = Division.objects.create('ocd-division/country:us/state:ak/county:mild/place:a/x:y',
-                                     name='A')
+    Division.objects.create('ocd-division/country:us/state:ak/county:wild', name='Wild')
+    Division.objects.create('ocd-division/country:us/state:ak/county:mild', name='Mild')
+    Division.objects.create('ocd-division/country:us/state:ak/county:wild/place:a', name='A')
+    Division.objects.create('ocd-division/country:us/state:ak/county:wild/place:b', name='B')
+    Division.objects.create('ocd-division/country:us/state:ak/county:wild/school:a', name='A')
+    Division.objects.create('ocd-division/country:us/state:ak/county:mild/place:a', name='A')
+    Division.objects.create('ocd-division/country:us/state:ak/county:mild/place:a/x:y', name='A')
 
     # simplest ==
     assert Division.objects.children_of('ocd-division/country:us')[0].id == ak.id

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,11 @@ deps = pytest
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 opencivicdata --exclude opencivicdata/division-ids
+commands = flake8 opencivicdata
 
 [pytest]
 norecursedirs = opencivicdata/division-ids .*
+
+[flake8]
+max-line-length = 99
+exclude = opencivicdata/migrations,opencivicdata/division-ids


### PR DESCRIPTION
once again, surfaced what is likely a real bug

opencivicdata/models/bill.py:41:16: F821 undefined name 'defaultfilters'  
opencivicdata/models/bill.py:44:16: F821 undefined name 'defaultfilters'  

this is old thom admin code, probably can confirm we don't use these and then delete these functions