### PR TITLE
Add agency and corporation org classifications

### DIFF
--- a/opencivicdata/common.py
+++ b/opencivicdata/common.py
@@ -64,6 +64,8 @@ ORGANIZATION_CLASSIFICATION_CHOICES = (
     ('party', 'Party'),
     ('committee', 'Committee'),
     ('commission', 'Commission'),
+    ('corporation', 'Corporation'),
+    ('agency', 'Agency'),
     ('department', 'Department'),
 )
 ORGANIZATION_CLASSIFICATIONS = _keys(ORGANIZATION_CLASSIFICATION_CHOICES)


### PR DESCRIPTION
Toronto uses these labels as important designations outside regular standing committees.
See: http://www1.toronto.ca/wps/portal/contentonly?vgnextoid=3426ea64460b3410VgnVCM10000071d60f89RCRD