### PR TITLE
Added motion BILL_CLASSIFICATION

### DIFF
--- a/opencivicdata/common.py
+++ b/opencivicdata/common.py
@@ -87,7 +87,8 @@ BILL_CLASSIFICATION_CHOICES = (
     ('order', 'Order'),
     ('concurrent order', 'Concurrent Order'),
     ('appropriation', 'Appropriation'),
-    ('ordinance', 'Ordinance')
+    ('ordinance', 'Ordinance'),
+    ('motion', 'Motion'),
 )
 BILL_CLASSIFICATIONS = _keys(BILL_CLASSIFICATION_CHOICES)
 


### PR DESCRIPTION
San Francisco defines a motion as a "formal proposal for action", which doesn't seem to be obviously covered elsewhere.

http://www.sfbos.org/index.aspx?page=9507

fwiw, SF also uses [ordinances](http://www.sfbos.org/index.aspx?page=9506), and [resolutions](http://www.sfbos.org/index.aspx?page=9505)