### PR TITLE
Added new organization classification: department

### DIFF
--- a/opencivicdata/common.py
+++ b/opencivicdata/common.py
@@ -64,6 +64,7 @@ ORGANIZATION_CLASSIFICATION_CHOICES = (
     ('party', 'Party'),
     ('committee', 'Committee'),
     ('commission', 'Commission'),
+    ('department', 'Department'),
 )
 ORGANIZATION_CLASSIFICATIONS = _keys(ORGANIZATION_CLASSIFICATION_CHOICES)
 


### PR DESCRIPTION
San Francisco refers lots of things to non-committees. Currently, these need to be ignored, as pupa can't resolve them correctly. Would be great to store them as organizations.

Examples from [the departments page](https://sfgov.legistar.com/Departments.aspx) (select View > Past):

* Human Resources Department
* District Attorney
* County Clerk
* City Administrator
* Public Works Department