### PR TITLE
update pytest required version to try to get travis tests passing

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=2.9
 pytest-cov
 pytest-django
 coveralls


### PR DESCRIPTION
This fixes the currently failing travis test for python 3.4